### PR TITLE
$currentPage needs to be of type int

### DIFF
--- a/src/Utils/SearchTranslationsUtils.php
+++ b/src/Utils/SearchTranslationsUtils.php
@@ -71,7 +71,7 @@ final class SearchTranslationsUtils implements SearchTranslationsUtilsInterface
         } else {
             $pagerFanta->setMaxPerPage(50);
         }
-        $pagerFanta->setCurrentPage($request->query->get('page', 1));
+        $pagerFanta->setCurrentPage((int) $request->query->get('page', 1));
 
         return $pagerFanta;
     }


### PR DESCRIPTION
Solving
`Pagerfanta\Pagerfanta::setCurrentPage(): Argument #1 ($currentPage) must be of type int, string given, called in vendor/locastic/symfony-translation-bundle/src/Utils/SearchTranslationsUtils.php on line 74`

(occured with pagerfanta/pagerfanta Version 3.8.0)